### PR TITLE
Optionally require that tickets be forwarded

### DIFF
--- a/servconf.c
+++ b/servconf.c
@@ -101,6 +101,7 @@ initialize_server_options(ServerOptions *options)
 	options->gss_cleanup_creds = -1;
 	options->gss_strict_acceptor = -1;
 	options->gss_store_rekey = -1;
+	options->gss_req_deleg_creds_for = NULL;
 	options->password_authentication = -1;
 	options->kbd_interactive_authentication = -1;
 	options->challenge_response_authentication = -1;
@@ -332,7 +333,7 @@ typedef enum {
 	sHostbasedUsesNameFromPacketOnly, sClientAliveInterval,
 	sClientAliveCountMax, sAuthorizedKeysFile, sAuthorizedKeysFile2,
 	sGssAuthentication, sGssCleanupCreds, sGssStrictAcceptor,
-	sGssKeyEx, sGssStoreRekey,
+	sGssKeyEx, sGssStoreRekey, sGssReqDelCredsFor,
 	sAcceptEnv, sPermitTunnel,
 	sMatch, sPermitOpen, sForceCommand, sChrootDirectory,
 	sUsePrivilegeSeparation, sAllowAgentForwarding,
@@ -401,6 +402,7 @@ static struct {
 	{ "gssapistrictacceptorcheck", sGssStrictAcceptor, SSHCFG_GLOBAL },
 	{ "gssapikeyexchange", sGssKeyEx, SSHCFG_GLOBAL },
 	{ "gssapistorecredentialsonrekey", sGssStoreRekey, SSHCFG_GLOBAL },
+	{ "gssapirequiredelegatedcredentialsfor", sGssReqDelCredsFor, SSHCFG_GLOBAL },
 #else
 	{ "gssapiauthentication", sUnsupported, SSHCFG_ALL },
 	{ "gssapicleanupcredentials", sUnsupported, SSHCFG_GLOBAL },
@@ -408,6 +410,7 @@ static struct {
 	{ "gssapistrictacceptorcheck", sUnsupported, SSHCFG_GLOBAL },
 	{ "gssapikeyexchange", sUnsupported, SSHCFG_GLOBAL },
 	{ "gssapistorecredentialsonrekey", sUnsupported, SSHCFG_GLOBAL },
+	{ "gssapirequiredelegatedcredentialsfor", sUnsupported, SSHCFG_GLOBAL },
 #endif
 	{ "gssusesessionccache", sUnsupported, SSHCFG_GLOBAL },
 	{ "gssapiusesessioncredcache", sUnsupported, SSHCFG_GLOBAL },
@@ -980,6 +983,10 @@ process_server_config_line(ServerOptions *options, char *line,
 	case sGssStoreRekey:
 		intptr = &options->gss_store_rekey;
 		goto parse_flag;
+
+	case sGssReqDelCredsFor:
+	        options->gss_req_deleg_creds_for = strdup(arg = strdelim(&cp));
+		break;
 
 	case sPasswordAuthentication:
 		intptr = &options->password_authentication;

--- a/servconf.h
+++ b/servconf.h
@@ -101,6 +101,7 @@ typedef struct {
 	int     gss_cleanup_creds;	/* If true, destroy cred cache on logout */
 	int 	gss_strict_acceptor;	/* If true, restrict the GSSAPI acceptor name */
 	int 	gss_store_rekey;
+        char   *gss_req_deleg_creds_for; /* If not null, require tickets if the user is a member of the specified group */
 	int     password_authentication;	/* If true, permit password
 						 * authentication. */
 	int     kbd_interactive_authentication;	/* If true, permit */


### PR DESCRIPTION
In some systems, such as the MIT athena.dialup.mit.edu servers, AFS is
used for home directories.  AFS requires that Kerberos tickets are
available to be converted to "tokens", so that files can be then be
accessed.  For a system that allows authentication via
GSSAPIAuthenication, it's possible to get into a state where a user
has successfully logged in, but then cannot read any files.  To
prevent this confusion, allow the system administrator to specify
"GSSAPIRequireDelegatedCredentialsFor" with a group to force those
users to also provide GSSAPIDelegateCredentials, or else drop down to
keyboard-interactive/password authenication, which would allow a
properly-configured PAM stack to then get tickets and tokens.

This does not change any behavior of gss-openssh unless explicitly
enabled by the system administrator.
