### PR TITLE
Support Generic GSS-API Mechanisms

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3642,13 +3642,14 @@ AC_ARG_WITH(kerberos5,
 			blibpath="$blibpath:${KRB5ROOT}/lib"
 		fi
 
-		AC_CHECK_HEADERS(gssapi.h gssapi/gssapi.h)
+		AC_CHECK_HEADERS(gssapi.h gssapi/gssapi.h gssapi/gssapi_ext.h)
 		AC_CHECK_HEADERS(gssapi_krb5.h gssapi/gssapi_krb5.h)
 		AC_CHECK_HEADERS(gssapi_generic.h gssapi/gssapi_generic.h)
 
 		LIBS="$LIBS $K5LIBS"
 		AC_SEARCH_LIBS(k_hasafs, kafs, AC_DEFINE(USE_AFS, 1,
 			[Define this if you want to use libkafs' AFS support]))
+		AC_CHECK_FUNCS( gss_localname gss_userok)
 	fi
 	]
 )

--- a/ssh-gss.h
+++ b/ssh-gss.h
@@ -33,6 +33,9 @@
 #elif defined(HAVE_GSSAPI_GSSAPI_H)
 #include <gssapi/gssapi.h>
 #endif
+#ifdef HAVE_GSSAPI_GSSAPI_EXT_H
+#include <gssapi/gssapi_ext.h>
+#endif
 
 #ifdef KRB5
 # ifndef HEIMDAL
@@ -80,10 +83,11 @@ typedef struct {
 } ssh_gssapi_ccache;
 
 typedef struct {
+  gss_OID_desc oid;
 	gss_buffer_desc displayname;
 	gss_buffer_desc exportedname;
 	gss_cred_id_t creds;
-	gss_name_t name;
+  gss_name_t cred_name, ctx_name;
 	struct ssh_gssapi_mech_struct *mech;
 	ssh_gssapi_ccache store;
 	int used;
@@ -106,7 +110,7 @@ typedef struct {
 	OM_uint32	minor; /* both */
 	gss_ctx_id_t	context; /* both */
 	gss_name_t	name; /* both */
-	gss_OID		oid; /* client */
+	gss_OID		oid; /* both */
 	gss_cred_id_t	creds; /* server */
 	gss_name_t	client; /* server */
 	gss_cred_id_t	client_creds; /* both */


### PR DESCRIPTION
Previously, OpenSSH required that mechanisms be registered in a static
table within the ssh server.  There are three reasons for this:
- To meet requirements from RFC 4462 about which mechanisms are used
- To have mechanism-specific code to determine whether a user is authorized
- A mechanism-specific implementation of localname

Since then the GSS-API vendors have added support for gss_localname
and gss_userok.  In addition, mechanism attributes allow sshd to probe
for which mechanisms meet the requirements from RFC 4462.

Add support for arbitrary GSS-API mechanisms using gss_localname and
gss_userok.  Filter out negotiation mechanisms.
